### PR TITLE
gettimeofday関数の月の日数計算を改善

### DIFF
--- a/apps/newlib_support.c
+++ b/apps/newlib_support.c
@@ -122,25 +122,14 @@ int gettimeofday(struct timeval *tv, void* tz) {
     }
   }
 
+  static const int month_days[12] = {
+    31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+  };
   for(int m = 1; m < t.Month; m++) {
-    switch(m){
-      case 1:  days += 31;
-      case 2:
-        if(is_leap_year(t.Year)){
-          days += 29;
-        }else{
-          days += 28;
-        }
-      case 3:  days += 31;
-      case 4:  days += 30;
-      case 5:  days += 31;
-      case 6:  days += 30;
-      case 7:  days += 31;
-      case 8:  days += 31;
-      case 9:  days += 30;
-      case 10: days += 31;
-      case 11: days += 30;
-      case 12: days += 31;
+    if(m == 2 && is_leap_year(t.Year)) {
+      days += 29;
+    } else {
+      days += month_days[m-1];
     }
   }
 


### PR DESCRIPTION
実際にはswitch文にfallthroughバグがあったようで、GitHub Copilotが修正・最適化してくれました
(OS開発で初歩的ミスとかアホすぎだｒ(((((()
これで #3 は解決します(ズレなくなりました)

<img width="737" height="448" alt="スクリーンショット 2025-08-07 100624" src="https://github.com/user-attachments/assets/823c2d70-2aa4-43fc-9672-b023135611b3" />
